### PR TITLE
Fix install script URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Agents written in `.ag` use LLMs to think, but that is where the similarity to p
 ## Install
 
 ```bash
-curl -fsSL https://github.com/Replikanti/agentis/releases/latest/download/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/Replikanti/agentis/main/install.sh | sh
 ```
 
 Or download the binary for your platform manually from [Releases](https://github.com/Replikanti/agentis/releases).


### PR DESCRIPTION
## Summary

- Changes install script URL from release asset path to `raw.githubusercontent.com/Replikanti/agentis/main/install.sh`
- Stable URL that does not depend on a specific release tag
- Release asset `install.sh` was already removed from v1.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)